### PR TITLE
Add "how to use" in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@
 *.ist
 # indexstyle includes the Header of the site
 !indexstyle.ist
+
+# latexmk files
+*.fls
+*.fdb_latexmk

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@
 *.xml
 *.lol
 *.gz(busy)
+
+# makeindex style file created by the glossaries package
+*.ist
+# indexstyle includes the Header of the site
+!indexstyle.ist

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,0 +1,2 @@
+$pdf_mode = 1; 
+@default_files = ('main.tex');

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Die Vorlage wurde erfolgreich unter der [TEX Live](http://tug.org/texlive/) Umge
 
 **Optionale Software:**
 
-* git (zum Clonen und Contributen)
-* perl (für ```Latexmk```)
+* ```git``` (zum Clonen und Contributen)
+* ```perl``` (für ```latexmk```)
+* ```latexmk``` (über MikTex)
 
 ### Linux (getestet mit Debian Jessie)
 **Benötigte Software:**
@@ -51,22 +52,32 @@ Die Vorlage wurde erfolgreich unter der [TEX Live](http://tug.org/texlive/) Umge
 
 **Optionale Software:**
 
-* git (zum Clonen und Contributen)
-* perl (für ```Latexmk```)
+* ```git``` (zum Clonen und Contributen)
+* ```perl``` (für ```latexmk```)
+* ```latexmk``` (über MikTex)
 
 ## Runterladen der LaTeX Dateien
 Die Vorlage kann entweder mit ```git clone https://github.com/a-czyrny/LaTeX-Master-Vorlage.git``` (siehe optionale Software) oder mit über die GitHub Seite als *.zip Datei runtergeladen werden.
 
 
 ## Bearbeiten und Compilieren der LaTeX Dateien
-Unter **Windows** kann TexStudio genutzt werden, die Vorlage den eigenen Bedürfnissen anzupassen und zu compilieren.
-Um die Vorlage mit TexStudio zu bearbeiten, muss die main.tex mit TexStudio geöffnet werden.
-Mit ```F5``` wird dann das PDF erstellt.
+###Windows
+Unter **Windows** ist [TexStudio](http://www.texstudio.org/) als Editor empfohlen.
 
-**Achtung**
+Wenn die Standardeinstellungen von TexStudio genutzt werden, müssen noch zwei manuelle Schritte durchgeführt werden:
+1. Die Referenzen für das Glossar und das Abkürzungsverzeichnis müssen erstellt werden. In der Kommandozeile in dem Ordner der Vorlage:
 
-Um Referenzen korrekt aufzulösen, muss das Dokument mehrfach compiliert werden. Zweimal hintereinander ```F5``` löst dieses Problem.
+    makeindex -s main.ist -t main.alg -o main.acr main.acn
+    makeindex -s main.ist -t main.glg -o main.gls main.glo 
 
+2. Das LaTeX Dokument muss zwei mal compiliert werden (```F5```) damit alle Referenzen aufgelöst werden.
+
+**Alternative** 
+
+Wenn ```latexmk``` installiert wurde (siehe optionale Software) kann im TexStudio unter "Optionen / TexStudio konfigurieren / Erzeugen" auch ```latexmk```als Standardkompiler angegeben werden.
+```latexmk```funktioniert dann auch von der Kommandozeile aus
+ 
+### Linux
 Unter **Linux** kann die Vorlage mit dem Texteditor der Wahl editiert werden. Zum compilieren kann ```lualatex``` genutzt werden:
 
     lualatex -synctex=1 -interaction=nonstopmode main
@@ -76,6 +87,10 @@ Unter **Linux** kann die Vorlage mit dem Texteditor der Wahl editiert werden. Zu
     makeindex -s main.ist -t main.glg -o main.gls main.glo
     lualatex -synctex=1 -interaction=nonstopmode main
     lualatex -synctex=1 -interaction=nonstopmode main
+    
+**Alternative**
+Wenn ```latexmk``` installiert wurde (siehe optionale Software) kann in dem Verzeichnis auch ```latexmk```angegeben werden. Dies führt die oben genannten Schritte aus.
+    
 
 # Contributing 
 Die Funktionskommentare innerhalb der *.tex Dateien sind größtenteils auf Deutsch. 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # LaTeX-Master-Vorlage
 
-Die Latex-Master-Vorlage kann für Forschungsprojekte, Bachelor- und Masterarbeiten optimal genutzt werden. Notwendigen Pakete sind bereits eingebunden und Einstellungen vorgenommen. Die Funktionskommentare innerhalb der *.tex Dateien sind größtenteils auf Deutsch. Ergänzungen Anderer können jedoch in englischer Sprache ausfallen. Diese werden, wenn notwendig, zeitnah übersetzt.
+Die Latex-Master-Vorlage kann für Forschungsprojekte, Bachelor- und Masterarbeiten optimal genutzt werden. Notwendigen Pakete sind bereits eingebunden und Einstellungen vorgenommen. 
 
-# Empfohlene Umgebung
+Diese LaTeX Vorlage wurde bereits für Masterarbeiten an der Hochschule für Technik und Wirtschaft Berlin (HTW Berlin), Fachbereich 4 genutzt.
 
+Wenn diese Vorlage für deine Arbeit (oder Forschungsprojekt) genutzt wurde, schreibe bitte den Professor/Prüfer unten an die Liste. 
+
+# Beispiel-PDF
+
+[PDF Ansehen](main.pdf)
+
+# Benutzung
+
+Um diese Vorlage nutzen zu können muss die benötigte Software installiert werden. Sobald dies der Fall ist, kann die Vorlage runtergeladen und angepasst werden.
+
+## Empfohlene Umgebung
 Die Vorlage wurde erfolgreich unter der [TEX Live](http://tug.org/texlive/) Umgebung mit folgenden Programmen kompiliert.
 
 - **Compiler**: lualatex
@@ -11,10 +22,65 @@ Die Vorlage wurde erfolgreich unter der [TEX Live](http://tug.org/texlive/) Umge
 - **Index**: makeindex (Ergänzungen unter Anmerkungen beachten)
 - **Glossar**: makeglossaries
 
-# Beispiel-PDF
+## Installieren der benötigten Software
+### Windows
+**Benötigte Software:**
 
-[PDF Ansehen](main.pdf)
+* MikTex
+* TexStudio
 
+**Optionale Software:**
+
+* git (zum Clonen und Contributen)
+* perl (für ```Latexmk```)
+
+### Linux (getestet mit Debian Jessie)
+**Benötigte Software:**
+
+* wget (```apt-get -y install wget```)
+* texlive (```apt-get -y install texlive```)
+* texlive Pakete:
+        wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz &&\
+        tar -xzvf install-tl-unx.tar.gz &&\
+        rm install-tl-unx.tar.gz
+        echo I | install-tl*/install-tl
+* Pakete zu Path hinzufügen
+        PATH=/usr/local/texlive/2015/bin/x86_64-linux:$PATH    
+* Noch mehr settings:
+        tlmgr conf texmf TEXMFHOME "/usr/local/texlive/2015/bin/x86_64-linux"
+
+**Optionale Software:**
+
+* git (zum Clonen und Contributen)
+* perl (für ```Latexmk```)
+
+## Runterladen der LaTeX Dateien
+Die Vorlage kann entweder mit ```git clone https://github.com/a-czyrny/LaTeX-Master-Vorlage.git``` (siehe optionale Software) oder mit über die GitHub Seite als *.zip Datei runtergeladen werden.
+
+
+## Bearbeiten und Compilieren der LaTeX Dateien
+Unter **Windows** kann TexStudio genutzt werden, die Vorlage den eigenen Bedürfnissen anzupassen und zu compilieren.
+Um die Vorlage mit TexStudio zu bearbeiten, muss die main.tex mit TexStudio geöffnet werden.
+Mit ```F5``` wird dann das PDF erstellt.
+
+**Achtung**
+
+Um Referenzen korrekt aufzulösen, muss das Dokument mehrfach compiliert werden. Zweimal hintereinander ```F5``` löst dieses Problem.
+
+Unter **Linux** kann die Vorlage mit dem Texteditor der Wahl editiert werden. Zum compilieren kann ```lualatex``` genutzt werden:
+
+    lualatex -synctex=1 -interaction=nonstopmode main
+    biber main
+    makeindex main
+    makeindex -s main.ist -t main.alg -o main.acr main.acn
+    makeindex -s main.ist -t main.glg -o main.gls main.glo
+    lualatex -synctex=1 -interaction=nonstopmode main
+    lualatex -synctex=1 -interaction=nonstopmode main
+
+# Contributing 
+Die Funktionskommentare innerhalb der *.tex Dateien sind größtenteils auf Deutsch. 
+Ergänzungen Anderer können jedoch in englischer Sprache ausfallen. Diese werden, wenn notwendig, zeitnah übersetzt.
+  
 # Anmerkungen
 ## Stichwortverzeichnis
 Zum Erzeugen des Glossar und Abkürzungsverzeichnis muss "makeinxed" wie folgt aufgerufen werden:
@@ -26,3 +92,6 @@ Zum Erzeugen des Glossar und Abkürzungsverzeichnis muss "makeinxed" wie folgt a
 Der Titel im Header der Seite muss zusätzlich in der Style-Datei "[indexstyle.ist](indexstyle.ist)" angepasst werden:
 
 siehe: preamble "\\\markboth{**STICHWORTVERZEICHNIS**}{}\n\n\\begin{theindex}\n"
+
+# Welcher Professororen/ Prüfer haben Arbeiten mit dieser Vorlage bereits zugestimmt?
+* Prof. Dr. Fortenbacher, Masterarbeit


### PR DESCRIPTION
To enable other users to use this document, I added a section "Benutzung" in the README.md.
Also, I extended the .gitignore to not track *.ist files (except for the indexstyle.ist)

This PR also enables the `latexmk`command in the commandline (if installed, see README.md)
